### PR TITLE
Change Export to Clipboard to give compressed JSON

### DIFF
--- a/GatherRouteDB.cs
+++ b/GatherRouteDB.cs
@@ -71,7 +71,7 @@ public class GatherRouteDB
             ImGui.SameLine();
             if (ImGui.Button("Export to clipboard"))
             {
-                ImGui.SetClipboardText(SaveToJSONWaypoints(r.Waypoints).ToString());
+                ImGui.SetClipboardText(SaveToJSONWaypoints(r.Waypoints).ToString(formatting: 0));
             }
 
             if (_waypointToModify != null)

--- a/GatherRouteExec.cs
+++ b/GatherRouteExec.cs
@@ -153,7 +153,7 @@ public class GatherRouteExec : IDisposable
             Finish();
         }
         ImGui.SameLine();
-        ImGui.TextUnformatted($"Executing: {CurrentRoute.Name} #{CurrentWaypoint}: [{wp.Position.X:f3}, {wp.Position.Y:f3}, {wp.Position.Z:f3}] +- {wp.Radius:f3} (dist={(curPos - wp.Position).Length():f3}) @ {wp.InteractWithName} ({wp.InteractWithOID:X})");
+        ImGui.TextUnformatted($"Executing: {CurrentRoute.Name} #{CurrentWaypoint+1}: [{wp.Position.X:f3}, {wp.Position.Y:f3}, {wp.Position.Z:f3}] +- {wp.Radius:f3} (dist={(curPos - wp.Position).Length():f3}) @ {wp.InteractWithName} ({wp.InteractWithOID:X})");
     }
 
     private unsafe GameObject* FindObjectToInteractWith(GatherRouteDB.Waypoint wp)


### PR DESCRIPTION
Removes the formatting when exporting the JSON to the clipboard, to make it slightly easier to share.