### PR TITLE
Update GatherRouteExec.cs

### DIFF
--- a/ffxiv_visland/Gathering/GatherRouteExec.cs
+++ b/ffxiv_visland/Gathering/GatherRouteExec.cs
@@ -47,7 +47,7 @@ public class GatherRouteExec : IDisposable
         _camera.SpeedH = _camera.SpeedV = default;
         _movement.DesiredPosition = player?.Position ?? new();
 
-        var gathering = Service.Condition[ConditionFlag.OccupiedInQuestEvent] || Service.Condition[ConditionFlag.OccupiedInEvent] || Service.Condition[ConditionFlag.OccupiedSummoningBell];
+        var gathering = Service.Condition[ConditionFlag.OccupiedInQuestEvent] || Service.Condition[ConditionFlag.OccupiedInEvent] || Service.Condition[ConditionFlag.OccupiedSummoningBell] || Service.Condition[ConditionFlag.Gathering];
         bool aboutToBeMounted = Service.Condition[ConditionFlag.Unknown57]; // condition 57 is set while mount up animation is playing
         if (player == null || player.IsCasting || gathering || aboutToBeMounted || Paused || CurrentRoute == null || CurrentWaypoint >= CurrentRoute.Waypoints.Count)
             return;


### PR DESCRIPTION
adds the `Gathering` interaction flag to the `gathering` var, preventing interact spam if we're already gathering with the target.