### PR TITLE
Fix error for trying to solve recs when not on island on boot.

### DIFF
--- a/ffxiv_visland/Workshop/WorkshopOCImport.cs
+++ b/ffxiv_visland/Workshop/WorkshopOCImport.cs
@@ -10,6 +10,7 @@ using Lumina.Excel;
 using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
@@ -432,6 +433,7 @@ public unsafe class WorkshopOCImport
         try
         {
             var mji = MJIManager.Instance();
+            if (mji->IsPlayerInSanctuary == 0) return new();
             var state = new WorkshopSolver.FavorState();
             var offset = nextWeek ? 6 : 3;
             for (int i = 0; i < 3; ++i)


### PR DESCRIPTION
When the plugin loads, it tries to get solver recs which will produce an error if the player is not on the island, which as it's setup produces a message in chat saying "Object reference not set to an instance of an object" twice (once per each list trying to be created).

This just checks if the player is on the island first before continuing.