### PR TITLE
Add `FilteredRoutes` as a source of data

### DIFF
--- a/ffxiv_visland/Gathering/GatherWindow.cs
+++ b/ffxiv_visland/Gathering/GatherWindow.cs
@@ -160,7 +160,8 @@ public class GatherWindow : Window, IDisposable
             {
                 for (int i = 0; i < (FilteredRoutes.Count > 0 ? FilteredRoutes.Count : RouteDB.Routes.Count); i++)
                 {
-                    var route = RouteDB.Routes[i];
+                    var routeSource = FilteredRoutes.Count > 0 ? FilteredRoutes : RouteDB.Routes;
+                    var route = routeSource[i];
                     var selectedRoute = ImGui.Selectable($"{route.Name} ({route.Waypoints.Count} steps)###{i}", i == selectedRouteIndex);
                     if (selectedRoute)
                         selectedRouteIndex = i;


### PR DESCRIPTION
The list of routes would show the amount of routes based on the results of the search, however it would not show the results from the search.
Now if there are search results it will pull route data from `FilteredRoutes` instead of `RouteDB`.

Would fix #32.