### PR TITLE
Get the current loop status from the window

### DIFF
--- a/ffxiv_visland/Gathering/GatherRouteExec.cs
+++ b/ffxiv_visland/Gathering/GatherRouteExec.cs
@@ -20,7 +20,6 @@ public class GatherRouteExec : IDisposable
     public GatherRouteDB.Route? CurrentRoute;
     public int CurrentWaypoint;
     public bool ContinueToNext;
-    public bool LoopAtEnd;
     public bool Paused;
 
     private OverrideCamera _camera = new();
@@ -136,7 +135,7 @@ public class GatherRouteExec : IDisposable
                 if (++CurrentWaypoint >= CurrentRoute!.Waypoints.Count)
                 {
                     ThrottleTime = Environment.TickCount64;
-                    if (LoopAtEnd)
+                    if (GatherWindow.loop)
                     {
                         CurrentWaypoint = 0;
                     }
@@ -154,7 +153,6 @@ public class GatherRouteExec : IDisposable
         CurrentRoute = route;
         CurrentWaypoint = waypoint;
         ContinueToNext = continueToNext;
-        LoopAtEnd = loopAtEnd;
         _camera.Enabled = true;
         _movement.Enabled = true;
         ThrottleTime = Environment.TickCount64;
@@ -167,7 +165,6 @@ public class GatherRouteExec : IDisposable
         CurrentRoute = null;
         CurrentWaypoint = 0;
         ContinueToNext = false;
-        LoopAtEnd = false;
         _camera.Enabled = false;
         _movement.Enabled = false;
         if (Service.Config.Get<GatherRouteDB>().WasFlyingInManual)

--- a/ffxiv_visland/Gathering/GatherWindow.cs
+++ b/ffxiv_visland/Gathering/GatherWindow.cs
@@ -27,7 +27,7 @@ public class GatherWindow : Window, IDisposable
     public GatherRouteExec Exec = new();
 
     private int selectedRouteIndex = -1;
-    private static bool loop;
+    public static bool loop;
 
     private readonly List<uint> Colours = Svc.Data.GetExcelSheet<UIColor>()!.Select(x => x.UIForeground).ToList();
     private Vector4 greenColor = new Vector4(0x5C, 0xB8, 0x5C, 0xFF) / 0xFF;
@@ -205,9 +205,8 @@ public class GatherWindow : Window, IDisposable
 
             ImGui.PushStyleColor(ImGuiCol.Button, loop ? greenColor : redColor);
             ImGui.PushStyleColor(ImGuiCol.ButtonHovered, loop ? greenColor : redColor);
-            using (ImRaii.Disabled(Exec.CurrentRoute != null))
-                if (ImGuiComponents.IconButton(FontAwesomeIcon.SyncAlt))
-                    loop ^= true;
+            if (ImGuiComponents.IconButton(FontAwesomeIcon.SyncAlt))
+                loop ^= true;
             ImGui.PopStyleColor(2);
             if (ImGui.IsItemHovered()) ImGui.SetTooltip("Loop Route");
             ImGui.SameLine();

--- a/ffxiv_visland/Gathering/GatherWindow.cs
+++ b/ffxiv_visland/Gathering/GatherWindow.cs
@@ -205,8 +205,9 @@ public class GatherWindow : Window, IDisposable
 
             ImGui.PushStyleColor(ImGuiCol.Button, loop ? greenColor : redColor);
             ImGui.PushStyleColor(ImGuiCol.ButtonHovered, loop ? greenColor : redColor);
-            if (ImGuiComponents.IconButton(FontAwesomeIcon.SyncAlt))
-                loop ^= true;
+            using (ImRaii.Disabled(Exec.CurrentRoute != null))
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.SyncAlt))
+                    loop ^= true;
             ImGui.PopStyleColor(2);
             if (ImGui.IsItemHovered()) ImGui.SetTooltip("Loop Route");
             ImGui.SameLine();


### PR DESCRIPTION
At the end of a loop it will now check the current loop-route selection instead of saving it.