### PR TITLE
Add/Remove Target from Waypoint Fix

### DIFF
--- a/ffxiv_visland/Gathering/GatherWindow.cs
+++ b/ffxiv_visland/Gathering/GatherWindow.cs
@@ -365,6 +365,7 @@ public class GatherWindow : Window, System.IDisposable
                 var target = Service.TargetManager.Target;
                 if (target != null)
                 {
+                    wp.InteractWithName = target.Name.ToString().ToLower();
                     wp.InteractWithOID = target.DataId;
                     RouteDB.NotifyModified();
                 }


### PR DESCRIPTION
Gathering mode doesn't work without the name of the target. The name is only loaded if you use the 'Add Waypoint - Interact with target' Adding a line to fill the 'InteractWithName' field when clicking 'Add/Remove Target From Waypoint' in the Waypoint menu.