### PR TITLE
Really Mediocre Route Groups

### DIFF
--- a/ffxiv_visland/Gathering/GatherRouteDB.cs
+++ b/ffxiv_visland/Gathering/GatherRouteDB.cs
@@ -71,6 +71,7 @@ public class GatherRouteDB : Configuration.Node
     public class Route
     {
         public string Name = "";
+        public string Group = "";
         public List<Waypoint> Waypoints = [];
     }
 
@@ -89,8 +90,14 @@ public class GatherRouteDB : Configuration.Node
             foreach (var jr in ja)
             {
                 var jn = jr["Name"]?.Value<string>();
+                var jg = jr["Group"]?.Value<string>();
                 if (jn != null && jr["Waypoints"] is JArray jw)
-                    Routes.Add(new Route() { Name = jn, Waypoints = LoadFromJSONWaypoints(jw) });
+                {
+                    if (jg != null)
+                        Routes.Add(new Route() { Name = jn, Group = jg, Waypoints = LoadFromJSONWaypoints(jw) });
+                    else
+                        Routes.Add(new Route() { Name = jn, Waypoints = LoadFromJSONWaypoints(jw) });
+                }
             }
         }
         DisableOnErrors = (bool?)j["DisableOnErrors"] ?? false;
@@ -107,6 +114,7 @@ public class GatherRouteDB : Configuration.Node
             res.Add(new JObject()
             {
                 { "Name", r.Name },
+                { "Group", r.Group },
                 { "Waypoints", SaveToJSONWaypoints(r.Waypoints) }
             });
         }


### PR DESCRIPTION
Added a group element that is stored along side the route name and is entered in the waypoint editing section under the name.

Recommend this PR get some amount scrutiny. I have no idea what I am doing and this is my first medium-ish plugin change. 

I choose to save the group at the same level as the name in the DB because I really didn't want to make huge changes to the JSON hierarchy and have to figure out how to fix everyone's existing JSON config file. (Ideally Group would have been its own level of the JSON which would probably make the display more efficient and would enable adding empty groups and moving the group organization from a text box to context menu/drag and drop)

I also choose to use CollapsingHeader for the groups instead of a tree because I couldn't figure out how the tree worked.

Would love some feedback on changes/improvements.