### PR TITLE
Rough implementation of SurveyNodeScan 

### DIFF
--- a/ffxiv_visland/Gathering/GatherRouteDB.cs
+++ b/ffxiv_visland/Gathering/GatherRouteDB.cs
@@ -78,7 +78,6 @@ public class GatherRouteDB : Configuration.Node
         public int QuestID;
         public int QuestSeq;
         public int MobID;
-        public string NodeScanTarget = "";
         public SurveyNodeType SurveyNodeType;
         public GrindStopConditions StopCondition;
         public int KillCount;

--- a/ffxiv_visland/Gathering/GatherRouteDB.cs
+++ b/ffxiv_visland/Gathering/GatherRouteDB.cs
@@ -39,6 +39,7 @@ public class GatherRouteDB : Configuration.Node
         EquipRecommendedGear = 10,
         ChatCommand = 11,
         NodeScan = 12,
+        SurveyNodeScan = 13
     }
 
     public enum GrindStopConditions
@@ -47,6 +48,16 @@ public class GatherRouteDB : Configuration.Node
         Kills = 1,
         QuestSequence = 2,
         QuestComplete = 3,
+    }
+
+    public enum SurveyNodeType 
+    {
+        Survey = 0,
+        Legendary = 1,
+        Unspoiled = 2,
+        // Unknown = 3,
+        Ephemeral = 4,
+        SwimmingShallows = 5
     }
 
     public class Waypoint
@@ -67,6 +78,8 @@ public class GatherRouteDB : Configuration.Node
         public int QuestID;
         public int QuestSeq;
         public int MobID;
+        public string NodeScanTarget = "";
+        public SurveyNodeType SurveyNodeType;
         public GrindStopConditions StopCondition;
         public int KillCount;
         public string RouteName = "";

--- a/ffxiv_visland/Gathering/GatherRouteExec.cs
+++ b/ffxiv_visland/Gathering/GatherRouteExec.cs
@@ -204,8 +204,8 @@ public class GatherRouteExec : IDisposable
                 var nodes = Svc.Objects.Where(x => x.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.GatheringPoint && x.IsTargetable)
                     .OrderBy(x => Vector3.DistanceSquared(x.Position, Player.Object.Position))
                     .Select((x, i) => new {Value = x, DistanceToLast = i > 0 ? Vector3.Distance(Svc.Objects.ElementAt(i - 1).Position, x.Position) : 0});
-                if (wp.NodeScanTarget != String.Empty)
-                    nodes = nodes.Where(x => x.Value.Name.TextValue.EqualsIgnoreCase(wp.NodeScanTarget)).Take(1);
+                if (wp.InteractWithName != String.Empty)
+                    nodes = nodes.Where(x => x.Value.Name.TextValue.EqualsIgnoreCase(wp.InteractWithName)).Take(1);
                 var waypoints = nodes.Select(node => new GatherRouteDB.Waypoint
                 {
                     IsPhantom = true,
@@ -248,7 +248,7 @@ public class GatherRouteExec : IDisposable
                     Position = targetPosition,
                     showInteractions = true,
                     Interaction = GatherRouteDB.InteractionType.NodeScan,
-                    NodeScanTarget = marker.TooltipText.ToString().Split(' ', 3).LastOrDefault(String.Empty),// breaks by space so "Lv. 60 Rocky Outcrop" gets split into {"Lv.", "60", "Rocky Outcrop"}
+                    InteractWithName = marker.TooltipText.ToString().Split(' ', 3).LastOrDefault(String.Empty),// breaks by space so "Lv. 60 Rocky Outcrop" gets split into {"Lv.", "60", "Rocky Outcrop"}
                     Radius = wp.Radius,
                     Movement = Vector3.Distance(Player.Object.Position, targetPosition) < 30 ? GatherRouteDB.Movement.Normal
                         : Player.ExclusiveFlying ? GatherRouteDB.Movement.MountFly

--- a/ffxiv_visland/Gathering/GatherWindow.cs
+++ b/ffxiv_visland/Gathering/GatherWindow.cs
@@ -13,7 +13,6 @@ using Lumina.Excel;
 using Lumina.Excel.GeneratedSheets;
 using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Numerics;
 using visland.Helpers;
@@ -615,6 +614,10 @@ public class GatherWindow : Window, System.IDisposable
                     ImGuiEx.TextV("Chat Command: ");
                     ImGui.SameLine();
                     if (ImGui.InputText("##chatCommand", ref wp.ChatCommand, 256))
+                        RouteDB.NotifyModified();
+                    break;
+                case InteractionType.SurveyNodeScan:
+                    if (UICombo.Enum("Node Type", ref wp.SurveyNodeType))
                         RouteDB.NotifyModified();
                     break;
             }

--- a/ffxiv_visland/IPC/vnavmeshIPC.cs
+++ b/ffxiv_visland/IPC/vnavmeshIPC.cs
@@ -22,7 +22,7 @@ internal class NavmeshIPC
 
     // query
     private static ICallGateSubscriber<Vector3, float, float, Vector3?>? _queryMeshNearestPoint;
-    private static ICallGateSubscriber<Vector3, float, Vector3?>? _queryMeshPointOnFloor;
+    private static ICallGateSubscriber<Vector3, bool, float, Vector3?>? _queryMeshPointOnFloor;
 
     // path
     private static ICallGateSubscriber<List<Vector3>, bool, object>? _pathMoveTo;
@@ -55,7 +55,7 @@ internal class NavmeshIPC
                 _navSetAutoLoad = Service.Interface.GetIpcSubscriber<bool, object>($"{Name}.Nav.SetAutoLoad");
 
                 _queryMeshNearestPoint = Service.Interface.GetIpcSubscriber<Vector3, float, float, Vector3?>($"{Name}.Query.Mesh.NearestPoint");
-                _queryMeshPointOnFloor = Service.Interface.GetIpcSubscriber<Vector3, float, Vector3?>($"{Name}.Query.Mesh.PointOnFloor");
+                _queryMeshPointOnFloor = Service.Interface.GetIpcSubscriber<Vector3, bool, float, Vector3?>($"{Name}.Query.Mesh.PointOnFloor");
 
                 _pathMoveTo = Service.Interface.GetIpcSubscriber<List<Vector3>, bool, object>($"{Name}.Path.MoveTo");
                 _pathStop = Service.Interface.GetIpcSubscriber<object>($"{Name}.Path.Stop");
@@ -135,7 +135,7 @@ internal class NavmeshIPC
     internal static void SetAutoLoad(bool value) => Execute(_navSetAutoLoad!.InvokeAction, value);
 
     internal static Vector3? QueryMeshNearestPoint(Vector3 pos, float halfExtentXZ, float halfExtentY) => Execute(() => _queryMeshNearestPoint!.InvokeFunc(pos, halfExtentXZ, halfExtentY));
-    internal static Vector3? QueryMeshPointOnFloor(Vector3 pos, float halfExtentXZ) => Execute(() => _queryMeshPointOnFloor!.InvokeFunc(pos, halfExtentXZ));
+    internal static Vector3? QueryMeshPointOnFloor(Vector3 pos, bool allowUnlandable, float halfExtentXZ) => Execute(() => _queryMeshPointOnFloor!.InvokeFunc(pos, allowUnlandable, halfExtentXZ));
 
     internal static void MoveTo(List<Vector3> waypoints, bool fly) => Execute(_pathMoveTo!.InvokeAction, waypoints, fly);
     internal static void Stop() => Execute(_pathStop!.InvokeAction);


### PR DESCRIPTION
This is a base implementation I've done for my own use, but I think it fits well with the NodeScan implementation that had been started and commented. The Node Type `Survey` is the kind revealed by actions like Lay of the Land.

Let me know if it fits with the project and if there's changes needed. I tried to fit the existing style (tight spacing, mostly).

Demo (use on Miner):

This will locate the nearest set of nodes, travel to it, then harvest the individual nodes.

`H4sIAAAAAAAACu1TTU/DMAz9K8jnCu0DJNQb6jZUoY1Bi8aHOITVWyM1cWncoWnafyfpUjbgsivSTrGf7eT5PWUDE6EQQkjqaoXrCWV4NkBFEMBNRXVpK4966SLMLDYiyiDsBDAWuhZFE87EuiSp2UD4uoEpGcmSNIQbeLL1c9vx7M+X5tzagDTGg2b6QWSytqN91zCmFSrUDGE3gKngfCG1fY+rGgOINWMl5jyTnN/56UPML2JZmpw+24qlYn7f0NC7CGCoiFseMaPy4XXT4ZJe7yqA+xoN+1ITJ/ix04DePexkS+ZCp6JaIu9I7AVN1yU2bQlTGZHOvEAWuZVFEVHtNnZaUM24XyPKBUeklHAatHvNhOTvhVwyournnQ5MpcKxbbvsHADD9K8p1ozYTHOhmRSEC1EYp5NxtH26Df6Rqd3+Ea62Pp48/R+e9k6eHvNP37Zfv3iFe80FAAA=`